### PR TITLE
Major fix to LinkTitle

### DIFF
--- a/modules/linktitle.py
+++ b/modules/linktitle.py
@@ -44,7 +44,9 @@ def _parseTitle(html):
 
 def _fetchTitle(url):
     global ismime
-    response = urllib2.urlopen(url)
+    opener = urllib2.build_opener()
+    opener.addheaders = [('User-agent',"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1")]
+    response = opener.open(url)
     mime = response.info().gettype()
     if mime != 'text/html':
         ismime = True


### PR DESCRIPTION
This offers two enhancements:
- Fixes cases where there are two </title> tags. Current page breaks on some sites, e.g. http://www.compuphase.com/pawn/pawn.htm
- makes it say Content-Type if it's using a mime type

This is at the expense of requiring the `BeautifulSoup` module, which really isn't that much added overhead when you consider this thing uses MySQL.
