### PR TITLE
Added autobanning and stuff

### DIFF
--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -1,16 +1,75 @@
 from api import *
+import random
+
 
 def load():
-    registerFunction("kick %s", kickUser, "kick <user>", restricted = True)
-    registerFunction("ban %s", banUser, "ban <ident>", restricted = True)
-    registerFunction("unban %s", unbanUser, "unban <ident>", restricted = True)
+    """ Kicking and banning management through the bot. """
+    dbExecute('''create table if not exists autobans (
+              banID int auto_increment primary key,
+              `nick` varchar(255) )''')
+    registerFunction("kick %S", kickUser, restricted=True)
+    registerFunction("ban %S", banUser, restricted=True)
+    registerFunction("autoban %s", autoBan, restricted=True)
+    registerFunction("clear bans", clearBans, restricted=True)
+    registerFunction("list bans", listBans)
+    registerCommandHandler("JOIN", checkBan)
 registerModule("KickBan", load)
 
+
+replies = ("someone must not like you at all", "oops, my bad",
+           "I am really, really sorry")
+
+
 def kickUser(channel, sender, target):
-    sendKick(channel, target, sender)
+    split = target.split(";")
+    for user in split[0].strip().split():
+        try:
+            sendKick(channel, user, split[1].strip())
+        except:
+            sendKick(channel, user, random.choice(replies))
+
 
 def banUser(channel, sender, target):
-    sendCommand("MODE %s +b %s" % (channel, target))
+    for user in target.split():
+        sendKick(channel, user, random.choice(replies))
+        sendCommand("MODE %s +b %s" % (channel, user))
 
-def unbanUser(channel, sender, target):
-    sendCommand("MODE %s -b %s" % (channel, target))
+
+def autoBan(channel, sender, target):
+    alreadyBanned = dbQuery('SELECT banID FROM autobans WHERE `nick`=%s',
+                            [target])
+    if len(alreadyBanned) != 0:
+        sendMessage(channel, "%s: %s is already auto banned." % (sender,
+                    target))
+    else:
+        sendKick(channel, target, random.choice(replies))
+        sendCommand("MODE %s +b %s" % (channel, target))
+        dbExecute('INSERT INTO autobans (`nick`) VALUES (%s)', [target])
+
+
+def listBans(channel, sender):
+    bannedUsers = dbQuery('SELECT banID, `nick` from autobans')
+    if len(bannedUsers) > 0:
+        listUsers = ""
+        for banID, nick in bannedUsers:
+            listUsers = listUsers + "%s, " % nick
+        sendMessage(channel, "%s: %s" % (sender, listUsers))
+    else:
+        sendMessage(channel, "No auto bans set.")
+
+
+def clearBans(channel):
+    bans = dbQuery('SELECT banID, `nick` from autobans')
+    for banID, nick in bans:
+        sendCommand("MODE %s -b %s" % (channel, nick))
+        dbExecute('DELETE FROM autobans WHERE banID=%s', [banID])
+    sendMessage(channel, "Cleared all bans.")
+
+
+def checkBan(channel, sender):
+    (nick, ident, hostname) = parseSender(sender)
+    isBanned = dbQuery('SELECT banID FROM autobans WHERE `nick`=%s', [nick])
+    if len(isBanned) > 0:
+        sendKick(channel[0], nick, random.choice(replies))
+        sendCommand("MODE %s +b %s" % (channel[0], nick))
+        dbExecute('INSERT INTO autobans (`nick`) VALUES (%s)', [nick])

--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -12,6 +12,7 @@ def load():
     registerFunction("autoban %s", autoBan, restricted=True)
     registerFunction("clear bans", clearBans, restricted=True)
     registerFunction("list bans", listBans)
+    registerFunction("unban %s", unbanUser)
     registerCommandHandler("JOIN", checkBan)
 registerModule("KickBan", load)
 
@@ -56,6 +57,14 @@ def listBans(channel, sender):
         sendMessage(channel, "%s: %s" % (sender, listUsers))
     else:
         sendMessage(channel, "No auto bans set.")
+
+
+def unbanUser(channel, sender, target):
+    isBanned = dbQuery('SELECT banID FROM autobans WHERE `nick`=%s',
+                       [target])
+    if len(isBanned) > 0:
+        sendCommand("MODE %s -b %s" % (channel, target))
+        dbExecute('DELETE FROM autobans WHERE `nick`=%s', [target])
 
 
 def clearBans(channel):

--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -9,10 +9,10 @@ def load():
               `nick` varchar(255) )''')
     registerFunction("kick %S", kickUser, restricted=True)
     registerFunction("ban %S", banUser, restricted=True)
+    registerFunction("unban %s", unbanUser, restricted=True)
     registerFunction("autoban %s", autoBan, restricted=True)
     registerFunction("clear bans", clearBans, restricted=True)
     registerFunction("list bans", listBans)
-    registerFunction("unban %s", unbanUser)
     registerCommandHandler("JOIN", checkBan)
 registerModule("KickBan", load)
 

--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -71,7 +71,7 @@ def clearBans(channel):
     bans = dbQuery('SELECT banID, `nick` from autobans')
     for banID, nick in bans:
         sendCommand("MODE %s -b %s" % (channel, nick))
-        dbExecute('DELETE FROM autobans WHERE banID=%s', [banID])
+    dbExecute('DELETE FROM autobans')
     sendMessage(channel, "Cleared all bans.")
 
 

--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -81,4 +81,3 @@ def checkBan(channel, sender):
     if len(isBanned) > 0:
         sendKick(channel[0], nick, random.choice(replies))
         sendCommand("MODE %s +b %s" % (channel[0], nick))
-        dbExecute('INSERT INTO autobans (`nick`) VALUES (%s)', [nick])

--- a/modules/kickban.py
+++ b/modules/kickban.py
@@ -26,7 +26,7 @@ def kickUser(channel, sender, target):
     for user in split[0].strip().split():
         try:
             sendKick(channel, user, split[1].strip())
-        except:
+        except IndexError:
             sendKick(channel, user, random.choice(replies))
 
 


### PR DESCRIPTION
Autobanning! *Yes!* When banning BradPitt is no longer a hassle.

Functions:
---
- kicking one or more users with the possibility of adding a reason (reason is separated by a semicolon)
- banning one or more users by nick *or* ident
- autobanning a user - even if a ban is manually unset for a user, his rejoin encounters a kick and ban
- clearing the bans - unbanning everyone in the auto ban list
- unbanning - we don't want to clear the whole list of auto bans for a single user
- listing the bans

Examples
---
- Kicking a user
  - bot, kick user1
  - bot, kick user1; reason
- Kicking multiple users
  - bot, kick user1 user2
  - bot, kick user1 user2; reason
- Banning a user
  - bot, ban user1
  - bot, ban *!*@*ident*
- Banning multiple users
  - bot, ban user1 *!aa@bb
- Unbanning
  - bot, unban user1
- Autobanning
  - bot, autoban user1
- Clearing auto ban list
  - bot, clear bans
- Printing the ban list
  - bot, list bans